### PR TITLE
Add sorting options

### DIFF
--- a/components/Button.vue
+++ b/components/Button.vue
@@ -1,0 +1,32 @@
+<template>
+  <button :class="[cls, active ? activeCls : '']" @click="$emit('click')">
+    <slot></slot>
+  </button>
+</template>
+
+<script>
+const classes = `
+  pl-3 pr-3 px-2 py-1
+  flex items-center
+  cursor-pointer
+  rounded-full
+  border border-gray-900 dark:border-gray-600
+  focus-within:shadow-focus focus:outline-none
+  bg-white dark:bg-black
+`;
+const activeClasses = "bg-gray-300 dark:bg-gray-700 font-bold";
+export default {
+  props: {
+    active: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      cls: classes,
+      activeCls: activeClasses,
+    };
+  },
+};
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,11 +4,11 @@ export default {
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
-    title: "shadesof.blue",
+    title: "Shades of Blue",
     meta: [
       { charset: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
-      { hid: "description", name: "description", content: "" },
+      { hid: "description", name: "description", content: "Look at all these shades of blue. Who knew there were so many shades of blue?" },
       { name: "format-detection", content: "telephone=no" },
     ],
     link: [

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -278,9 +278,11 @@ export default {
         s.family =
           hue <= 195 ? "Cyan" : hue > 195 && hue <= 225 ? "Azure" : "Blue";
       });
-      sort = sort.sort((a, b) => Math.round(b.hsv.v) - Math.round(a.hsv.v));
-      sort = sort.sort((a, b) => Math.round(a.hsv.s) - Math.round(b.hsv.s));
-      sort = sort.sort((a, b) => Math.round(a.hsv.h) - Math.round(b.hsv.h));
+      // sort = sort.sort((a, b) => Math.round(b.hsv.v) - Math.round(a.hsv.v));
+      // sort = sort.sort((a, b) => Math.round(a.hsv.s) - Math.round(b.hsv.s));
+      // sort = sort.sort((a, b) => Math.round(a.hsv.h) - Math.round(b.hsv.h));
+      sort = sort.sort((a, b) => Math.round(a.hwb.w) - Math.round(b.hsv.w));
+      sort = sort.sort((a, b) => Math.round(a.hwb.b) - Math.round(b.hsv.b));
       return sort;
     },
     count() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,7 +25,7 @@
         </button>
       </div>
       <p class="total | lg:ml-auto text-center">
-        Displaying <strong>{{ count }}</strong> / {{ c.length }} blues
+        Displaying <strong>{{ count }}</strong> / {{ Blues.length }} blues
         documented!
       </p>
       <Filters :open="filters.open">
@@ -118,7 +118,7 @@
         'swatches--labeled': filters.check.showLabels.value,
       }"
     >
-      <template v-for="(blue, i) in c">
+      <template v-for="(blue, i) in Blues">
         <Swatch
           :key="`${blue.slug}${blue.source}${i}`"
           :blue="blue"
@@ -262,7 +262,7 @@ export default {
     };
   },
   computed: {
-    c() {
+    Blues() {
       let sort = [...this.blues];
       sort.forEach((s) => {
         const b = Color(s.value);
@@ -285,8 +285,8 @@ export default {
     },
     count() {
       const filters = this.filters;
-      const c = [...this.c].filter((blue) => filterLogic(blue, filters));
-      return this.c.length - c.length;
+      const Blues = [...this.Blues].filter((blue) => filterLogic(blue, filters));
+      return this.Blues.length - Blues.length;
     },
   },
   methods: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,16 +13,9 @@
             type="search"
             class="rounded-full dark:bg-gray-800 [ text-black dark:text-white ] [ w-full lg:w-auto ] [ px-4 py-1 ] [ focus-within:shadow-focus focus:outline-none ] [ border border-gray-900 dark:border-gray-600 ]"
         /></label>
-        <button
-          class="pl-3 pr-3"
-          :class="[
-            classes.pill,
-            filters.open ? classes.pillSelected : 'bg-white dark:bg-black',
-          ]"
-          @click="filters.open = !filters.open"
-        >
+        <Button :active="filters.open" @click="filters.open = !filters.open">
           Options
-        </button>
+        </Button>
       </div>
       <p class="total | lg:ml-auto text-center">
         Displaying <strong>{{ count }}</strong> / {{ Blues.length }} blues
@@ -61,19 +54,13 @@
               class="hidden md:block border-r h-6 border-opacity-80 dark:border-opacity-20"
             ></div>
             <div class="flex flex-wrap gap-3">
-              <button
-                :class="[
-                  classes.pill,
-                  filters.gray !== 0 ? classes.pillSelected : '',
-                ]"
-                @click="toggleGray()"
-              >
+              <Button :active="filters.gray !== 0" @click="toggleGray()">
                 <span
                   class="rounded-full w-6 h-6 mr-2 bg-gray-300 dark:bg-gray-500 inline-flex items-center justify-center"
                   ><i class="fas fa-adjust"></i
                 ></span>
                 {{ filters.gray === 2 ? "Only grays" : "Grays" }}
-              </button>
+              </Button>
               <label
                 for="oob"
                 class="px-4 flex items-center"
@@ -110,11 +97,24 @@
             </label>
           </template>
         </div>
-        <div class="flex items-center py-2 flex-wrap">
-          <strong>Sorting</strong>
+        <div class="flex items-center py-2 flex-wrap gap-2">
+          <strong>Sort</strong>
           <div class="mx-2"></div>
           <template v-for="(op, i) in sort.options">
-            <button :key="i" @click="setSort(op)">{{ op }}</button>
+            <Button :key="i" :active="op === sort.method" @click="setSort(op)"
+              >{{ op
+              }}<span
+                class="ml-2"
+                :class="{ hidden: op === 'Default' || op !== sort.method }"
+              >
+                <span :class="{ hidden: !sort.desc }"
+                  ><i class="fa-duotone fa-arrow-down-9-1"></i
+                ></span>
+                <span :class="{ hidden: sort.desc }"
+                  ><i class="fa-duotone fa-arrow-up-1-9"></i
+                ></span>
+              </span>
+            </Button>
           </template>
         </div>
       </Filters>
@@ -215,11 +215,11 @@ const addProps = (arr) => {
 
 const sortBlues = (swatches, method = "off", desc = false) => {
   // all this function does is update the order prop for the swatches array.
-  // method values: "off" (default), "hue", "luminosity"
+  // method values: "Default (off)", "Hue", "Luminosity"
   // if desc is false, results will return in ascending order.
   let _s = [...swatches];
   switch (method) {
-    case "hue":
+    case "Hue":
       _s = _s.sort((a, b) => b.hsv.v - a.hsv.v);
       _s = _s.sort((a, b) => a.hsv.s - b.hsv.s);
       if (desc) {
@@ -228,7 +228,7 @@ const sortBlues = (swatches, method = "off", desc = false) => {
         _s = _s.sort((a, b) => a.hsv.h - b.hsv.h);
       }
       break;
-    case "luminosity":
+    case "Luminosity":
       _s = _s.sort((a, b) => b.lum - a.lum);
       if (desc) _s.reverse();
       break;
@@ -296,7 +296,7 @@ export default {
           selected: [],
         },
         gray: 0, // 0 hide 1 show 2 only
-        oob: true,
+        oob: false,
         libraries: {
           crayola: true,
           ntc: true,
@@ -309,8 +309,8 @@ export default {
         name: "",
       },
       sort: {
-        options: ["off", "hue", "luminosity"],
-        method: "off",
+        options: ["Default", "Hue", "Luminosity"],
+        method: "Default",
         desc: false,
       },
       libraries: [


### PR DESCRIPTION
This updates the default sort to showcase different blues and adds sorting options to see the swatches by hue or luminosity.

This is based on feedback that the site impression on load was... not as impactful since it was originally sorted by hue, starting with cyan - which is ambiguous to begin with (especially with darker shades of cyan, which can be perceived as "green").

So it was decided to keep the hue sort as an option and add luminosity (because it's pretty neat!).
